### PR TITLE
Messages/options

### DIFF
--- a/assets/components/chat/Message.tsx
+++ b/assets/components/chat/Message.tsx
@@ -1,4 +1,4 @@
-import {Button} from "@/components/ui/button.tsx";
+import { Button } from "@/components/ui/button.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -6,12 +6,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu.tsx";
-import {Textarea} from "@/components/ui/textarea.tsx";
-import {formatMessageTime} from "@/lib/time.ts";
-import {cn} from "@/lib/utils.ts";
-import type {Message} from "@/types.ts";
-import {Check, CheckCheck, Copy, Edit3, MoreVertical, Reply, Trash2, X} from "lucide-react";
-import {useState} from "react";
+import { Textarea } from "@/components/ui/textarea.tsx";
+import { formatMessageTime } from "@/lib/time.ts";
+import { cn } from "@/lib/utils.ts";
+import type { Message } from "@/types.ts";
+import { Check, CheckCheck, Copy, Edit3, MoreVertical, Reply, Trash2, X } from "lucide-react";
+import { useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -22,6 +22,7 @@ interface MessageComponentProps {
   onDelete?: (messageId: number) => void;
   onReply?: (message: Message) => void;
   onCopy?: (content: string) => void;
+  onScrollToMessage?: (messageId: number) => void;
   showReadStatus?: boolean;
 }
 
@@ -32,6 +33,7 @@ export function MessageComponent({
   onDelete,
   onReply,
   onCopy,
+  onScrollToMessage,
   showReadStatus = true
 }: MessageComponentProps) {
   const [isHovered, setIsHovered] = useState(false);
@@ -100,6 +102,7 @@ export function MessageComponent({
           setIsHovered(false);
         }
       }}
+      data-message-id={message.id}
     >
       {/* Quick Actions - Show on hover or when dropdown is open */}
       {shouldShowActions && (
@@ -199,6 +202,40 @@ export function MessageComponent({
         ) : (
           /* Normal Display Mode */
           <>
+            {/* Reply Preview - Show if this message is replying to another */}
+            {message.repliedMessage && (
+              <div
+                className={cn(
+                  "mb-3 p-3 rounded-lg border-l-4 text-xs transition-all cursor-pointer group",
+                  "shadow-sm hover:shadow-md",
+                  isMyMessage
+                    ? "bg-primary-foreground/10 border-primary-foreground/50 hover:bg-primary-foreground/15"
+                    : "bg-muted/80 border-muted-foreground/30 hover:bg-muted"
+                )}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onScrollToMessage?.(message.repliedMessage!.id);
+                }}
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <Reply className="h-3.5 w-3.5 opacity-60 group-hover:opacity-80 transition-opacity" />
+                  <span className="font-semibold text-xs opacity-90 group-hover:opacity-100 transition-opacity">
+                    {message.repliedMessage.sender.name}
+                  </span>
+                </div>
+                <div className="text-xs leading-relaxed opacity-75 group-hover:opacity-85 transition-opacity">
+                  {message.repliedMessage.content.split('\n').slice(0, 2).map((line, index) => (
+                    <p key={index} className="overflow-hidden text-ellipsis whitespace-nowrap">
+                      {line.length > 50 ? line.substring(0, 50) + "..." : line}
+                    </p>
+                  ))}
+                  {message.repliedMessage.content.split('\n').length > 2 && (
+                    <p className="opacity-60 italic">...</p>
+                  )}
+                </div>
+              </div>
+            )}
+
             <div className="break-words prose dark:prose-invert prose-sm">
               <Markdown remarkPlugins={[remarkGfm]}>
                 {message.content}

--- a/assets/lib/messages.ts
+++ b/assets/lib/messages.ts
@@ -6,8 +6,14 @@ import {useLocation} from "wouter";
 
 export function useMessages() {
   const user = useAppStore(state => state.user);
-  const { getMessagesChannelUrl, conversationsActions } = useAppStore.getState();
-  const { addMessage, getConversation , addConversation } = conversationsActions;
+  const {getMessagesChannelUrl, conversationsActions} = useAppStore.getState();
+  const {
+    addMessage,
+    getConversation,
+    addConversation,
+    deleteMessage,
+    updateMessage
+  } = conversationsActions;
   const [location, navigate] = useLocation();
   const [isOnPage, setIsOnPage] = useState(true);
   const changeIsOnPage = () => {
@@ -23,7 +29,7 @@ export function useMessages() {
       document.addEventListener("visibilitychange", changeIsOnPage);
 
       eventSource.addEventListener("message", (event) => {
-        const {event: messageEvent, message } = JSON.parse(event.data) as { event: MessageEventType, message: Message };
+        const {event: messageEvent, message} = JSON.parse(event.data) as { event: MessageEventType, message: Message };
 
         if (message.sender.id === user.id) {
           return; // Ignore messages sent by the current user
@@ -58,6 +64,14 @@ export function useMessages() {
                 }
               });
             }
+            break;
+
+          case "message.deleted":
+            deleteMessage(message.id);
+            break;
+
+          case "message.updated":
+            updateMessage(message);
             break;
         }
       });

--- a/assets/lib/messages.ts
+++ b/assets/lib/messages.ts
@@ -1,6 +1,6 @@
 import {useEffect, useState} from "react";
 import {useAppStore} from "@/lib/store.ts";
-import type {Message, MessageEvent as MessageEventType} from "@/types.ts";
+import type {MessageEvent as MessageEventType} from "@/types.ts";
 import {notify} from "@/lib/notifications.ts";
 import {useLocation} from "wouter";
 
@@ -29,7 +29,7 @@ export function useMessages() {
       document.addEventListener("visibilitychange", changeIsOnPage);
 
       eventSource.addEventListener("message", (event) => {
-        const {event: messageEvent, message} = JSON.parse(event.data) as { event: MessageEventType, message: Message };
+        const {event: messageEvent, message} = JSON.parse(event.data) as MessageEventType;
 
         if (message.sender.id === user.id) {
           return; // Ignore messages sent by the current user

--- a/assets/lib/store.ts
+++ b/assets/lib/store.ts
@@ -85,6 +85,26 @@ export const useAppStore = create(
               return state;
             });
           },
+          deleteMessage(messageId: number) {
+            set((state) => {
+              const updatedConversations = state.conversations.map(conversation => ({
+                ...conversation,
+                messages: conversation.messages.filter(m => m.id !== messageId)
+              }));
+              return { conversations: updatedConversations };
+            });
+          },
+          updateMessage(message: Message) {
+            set((state) => {
+              const updatedConversations = state.conversations.map(c => {
+                const messages = c.messages.map(m => {
+                  return m.id === message.id ? { ...m, ...message } : m;
+                });
+                return { ...c, messages };
+              });
+              return { conversations: updatedConversations };
+            })
+          },
           prependMessages(partnerId: number, messages: Message[]) {
             set((state) => {
               const conversationIndex = state.conversations.findIndex(c => c.partner.id === partnerId);

--- a/assets/pages/Chat/Discussion.tsx
+++ b/assets/pages/Chat/Discussion.tsx
@@ -96,8 +96,8 @@ export function Discussion({ params }: { params: { id: string } }) {
       fetchMessages()
         .then(async () => {
           if (conversation.unreadCount !== 0)
-            await apiFetch(`/api/messages/read?partnerId=${conversation.user.id}`)
-          switchMessagesLoaded(conversation.user.id);
+            await apiFetch(`/api/messages/read?partnerId=${conversation.partner.id}`)
+          switchMessagesLoaded(conversation.partner.id);
           scrollToBottom();
         });
     } else {

--- a/assets/pages/Chat/components/MessageList.tsx
+++ b/assets/pages/Chat/components/MessageList.tsx
@@ -12,6 +12,7 @@ interface MessageListProps {
     onDeleteMessage: (messageId: number) => void;
     onReplyToMessage: (message: Message) => void;
     onCopyMessage: (content: string) => void;
+    onScrollToMessage?: (messageId: number) => void;
     scrollAreaRef: React.RefObject<HTMLDivElement | null>;
 }
 
@@ -24,6 +25,7 @@ export function MessageList({
     onDeleteMessage,
     onReplyToMessage,
     onCopyMessage,
+    onScrollToMessage,
     scrollAreaRef,
 }: MessageListProps) {
     const isMyMessage = (message: Message) => message.sender.id === user.id;
@@ -49,6 +51,7 @@ export function MessageList({
                         onDelete={onDeleteMessage}
                         onReply={onReplyToMessage}
                         onCopy={onCopyMessage}
+                        onScrollToMessage={onScrollToMessage}
                         showReadStatus={true}
                     />
                 ))}

--- a/assets/pages/Chat/hooks/useChatActions.ts
+++ b/assets/pages/Chat/hooks/useChatActions.ts
@@ -1,28 +1,33 @@
-import { toast } from "sonner";
+import {toast} from "sonner";
+import {apiFetch} from "@/lib/fetch.ts";
+import {useAppStore} from "@/lib/store.ts";
+import type {Message} from "@/types.ts";
 
 export function useChatActions() {
+    const {deleteMessage, updateMessage} = useAppStore.getState().conversationsActions;
     // Message action handlers
     const handleEditMessage = async (messageId: number, newContent: string) => {
-        try {
-            // TODO: Implement API call to edit message
-            console.log("Edit message:", messageId, "New content:", newContent);
-
-            // For now, just show success message
-            toast.success("Message edited successfully");
-
-            // In a real implementation, you would:
-            // 1. Make API call to update message
-            // 2. Update the message in the store
-            // 3. Handle any errors
-        } catch (error) {
-            console.error("Failed to edit message:", error);
-            toast.error("Failed to edit message");
-        }
+        apiFetch<Message>(`/api/messages/${messageId}`, {
+            method: 'PUT',
+            data: {content: newContent},
+        })
+            .then((message) => {
+                updateMessage(message);
+                toast.success("Message edited successfully");
+            })
+            .catch(err => {
+                console.error("Failed to edit message:", err);
+                toast.error("Failed to edit message");
+            });
     };
 
     const handleDeleteMessage = (messageId: number) => {
-        // TODO: Implement delete functionality
-        console.log("Delete message:", messageId);
+        apiFetch(`/api/messages/${messageId}`, {
+            method: "DELETE"
+        }).then(() => {
+            deleteMessage(messageId)
+            toast.success("Message deleted successfully");
+        })
     };
 
     const handleCopyMessage = (_content: string) => {

--- a/assets/pages/Chat/hooks/useSendMessage.ts
+++ b/assets/pages/Chat/hooks/useSendMessage.ts
@@ -4,18 +4,13 @@ import {useAppStore} from "@/lib/store.ts";
 import type {Message} from "@/types.ts";
 import {toast} from "sonner";
 
-export function useSendMessage({partnerId}: { partnerId?: number }) {
+export function useSendMessage({partnerId, repliedMessage}: { partnerId?: number, repliedMessage: Message|null }) {
   const {addMessage} = useAppStore.getState().conversationsActions;
-  const url = new URL("/api/messages", location.origin);
-
-  if (partnerId) {
-    url.searchParams.append("partnerId", String(partnerId));
-  }
 
   const {
     loading: isSending,
     callback: sendMessageCallback
-  } = useApiFetch<Message, FormErrors>(url, {
+  } = useApiFetch<Message, FormErrors>(`/api/messages?partnerId=${partnerId || 0}&repliedMessageId=${repliedMessage?.id || 0}`, {
       method: "POST",
       onSuccess(message) {
         if (partnerId) {
@@ -28,7 +23,7 @@ export function useSendMessage({partnerId}: { partnerId?: number }) {
     }
   );
 
-  const sendMessage = async (content: string) => {
+  const sendMessage = async (content: string,) => {
     return sendMessageCallback({content});
   };
 

--- a/assets/types.ts
+++ b/assets/types.ts
@@ -32,3 +32,8 @@ export interface Contacts {
   groups: any[];
   loaded: boolean;
 }
+
+export interface MessageEvent {
+  event: "message.created" | "message.deleted" | "message.updated";
+  message: Message;
+}

--- a/assets/types.ts
+++ b/assets/types.ts
@@ -8,7 +8,7 @@ export interface User {
 }
 
 export interface Conversation {
-  user: Omit<User, "email" | "isVerified" | "role">;
+  partner: Omit<User, "email" | "isVerified" | "role">;
   messages: Message[];
   unreadCount: number;
   count: number;

--- a/assets/types.ts
+++ b/assets/types.ts
@@ -8,7 +8,7 @@ export interface User {
 }
 
 export interface Conversation {
-  partner: Omit<User, "email" | "isVerified" | "role">;
+  user: Omit<User, "email" | "isVerified" | "role">;
   messages: Message[];
   unreadCount: number;
   count: number;
@@ -24,9 +24,8 @@ export interface Message {
   modifiedAt: string;
   readAt?: string;
   editedAt?: string;
+  repliedMessage?: Message | null;
 }
-
-export type MessageEvent = "message.created"|"message.updated"|"message.deleted";
 
 export interface Contacts {
   friends: Omit<User, "email">[];

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/mercure-bundle": "^0.3.9",
         "symfony/messenger": "7.3.*",
         "symfony/notifier": "7.3.*",
+        "symfony/object-mapper": "7.3.*",
         "symfony/property-access": "7.3.*",
         "symfony/property-info": "7.3.*",
         "symfony/rate-limiter": "7.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4be2f85a8bfe2ba231578117c8acd3ae",
+    "content-hash": "f083761685ec560f7c2502f9e527b38a",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -4368,6 +4368,74 @@
                 }
             ],
             "time": "2025-05-01T12:12:53+00:00"
+        },
+        {
+            "name": "symfony/object-mapper",
+            "version": "v7.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/object-mapper.git",
+                "reference": "04c970c280b08c77a882a699f91cf5dd2e758387"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/object-mapper/zipball/04c970c280b08c77a882a699f91cf5dd2e758387",
+                "reference": "04c970c280b08c77a882a699f91cf5dd2e758387",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^2.0"
+            },
+            "conflict": {
+                "symfony/property-access": "<7.2"
+            },
+            "require-dev": {
+                "symfony/property-access": "^7.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ObjectMapper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to map an object to another object",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/object-mapper/tree/v7.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-19T13:11:22+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/migrations/Version20250726221802.php
+++ b/migrations/Version20250726221802.php
@@ -14,7 +14,7 @@ final class Version20250726221802 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'Add replied_message_id column to the message table to support message replies, including a foreign key constraint and an index.';
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20250726221802.php
+++ b/migrations/Version20250726221802.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250726221802 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE message ADD replied_message_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE message ADD CONSTRAINT FK_B6BD307FB5F4C8F4 FOREIGN KEY (replied_message_id) REFERENCES message (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_B6BD307FB5F4C8F4 ON message (replied_message_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE message DROP CONSTRAINT FK_B6BD307FB5F4C8F4');
+        $this->addSql('DROP INDEX IDX_B6BD307FB5F4C8F4');
+        $this->addSql('ALTER TABLE message DROP replied_message_id');
+    }
+}

--- a/src/Controller/MessagesController.php
+++ b/src/Controller/MessagesController.php
@@ -6,6 +6,7 @@ use App\Entity\Message;
 use App\Entity\User;
 use App\Enum\MessageEventType;
 use App\Event\MessageEvent;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -24,7 +25,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final class MessagesController extends AbstractController
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
+        private readonly EntityManagerInterface   $entityManager,
         private readonly EventDispatcherInterface $eventDispatcher,
     )
     {
@@ -34,10 +35,12 @@ final class MessagesController extends AbstractController
     public function create(
         #[MapRequestPayload] Message $message,
         #[CurrentUser] User          $user,
-        #[MapQueryParameter] ?int    $partnerId,
+        #[MapQueryParameter] int     $partnerId,
+        #[MapQueryParameter] int     $repliedMessageId
     ): JsonResponse
     {
         $partner = $this->entityManager->getRepository(User::class)->find($partnerId);
+        $repliedMessage = $this->entityManager->getRepository(Message::class)->find($repliedMessageId);
 
         if (!$partner) {
             throw $this->createNotFoundException("The user was not found.");
@@ -45,6 +48,7 @@ final class MessagesController extends AbstractController
 
         $message->setSender($user);
         $message->setReceiver($partner);
+        $message->setRepliedMessage($repliedMessage);
 
         $this->entityManager->persist($message);
         $this->entityManager->flush();
@@ -78,9 +82,9 @@ final class MessagesController extends AbstractController
 
     #[Route("/read", name: "read")]
     public function read(
-        #[CurrentUser] User $user,
+        #[CurrentUser] User       $user,
         #[MapQueryParameter] ?int $partnerId,
-        HubInterface $hub
+        HubInterface              $hub
     ): JsonResponse
     {
         $partner = $this->entityManager->getRepository(User::class)->find($partnerId);
@@ -108,6 +112,21 @@ final class MessagesController extends AbstractController
         $this->entityManager->remove($message);
         $this->entityManager->flush();
 
+        $this->eventDispatcher->dispatch(new MessageEvent($message, MessageEventType::DELETED));
+
         return $this->json(null, status: 204);
+    }
+
+    #[Route("/{id}", name: "edit", requirements: ["id" => Requirement::DIGITS], methods: ["PUT"])]
+    public function edit(
+        Message                      $message,
+        #[MapRequestPayload] Message $editedMessage,
+    ): JsonResponse
+    {
+        $message->setContent($editedMessage->getContent());
+        $message->setModifiedAt(new DateTimeImmutable());
+        $this->entityManager->flush();
+        $this->eventDispatcher->dispatch(new MessageEvent($message, MessageEventType::UPDATED));
+        return $this->json($message, context: ["groups" => ["messages:read"]]);
     }
 }

--- a/src/Controller/MessagesController.php
+++ b/src/Controller/MessagesController.php
@@ -36,11 +36,13 @@ final class MessagesController extends AbstractController
         #[MapRequestPayload] Message $message,
         #[CurrentUser] User          $user,
         #[MapQueryParameter] int     $partnerId,
-        #[MapQueryParameter] int     $repliedMessageId
+        #[MapQueryParameter] ?int    $repliedMessageId
     ): JsonResponse
     {
         $partner = $this->entityManager->getRepository(User::class)->find($partnerId);
-        $repliedMessage = $this->entityManager->getRepository(Message::class)->find($repliedMessageId);
+        $repliedMessage = $repliedMessageId !== null
+            ? $this->entityManager->getRepository(Message::class)->find($repliedMessageId)
+            : null;
 
         if (!$partner) {
             throw $this->createNotFoundException("The user was not found.");

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -47,6 +47,7 @@ class Message
     private ?string $content = null;
 
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'relatedMessages')]
+    #[Groups(["messages:read"])]
     private ?self $repliedMessage = null;
 
     /**
@@ -139,18 +140,6 @@ class Message
         return $this;
     }
 
-    public function getRepliedMessage(): ?self
-    {
-        return $this->repliedMessage;
-    }
-
-    public function setRepliedMessage(?self $repliedMessage): static
-    {
-        $this->repliedMessage = $repliedMessage;
-
-        return $this;
-    }
-
     /**
      * @return Collection<int, self>
      */
@@ -177,6 +166,18 @@ class Message
                 $relatedMessage->setRepliedMessage(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getRepliedMessage(): ?self
+    {
+        return $this->repliedMessage;
+    }
+
+    public function setRepliedMessage(?self $repliedMessage): static
+    {
+        $this->repliedMessage = $repliedMessage;
 
         return $this;
     }

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -4,6 +4,8 @@ namespace App\Entity;
 
 use App\Repository\MessageRepository;
 use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -44,10 +46,20 @@ class Message
     #[Assert\NotBlank]
     private ?string $content = null;
 
+    #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'relatedMessages')]
+    private ?self $repliedMessage = null;
+
+    /**
+     * @var Collection<int, self>
+     */
+    #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'repliedMessage')]
+    private Collection $relatedMessages;
+
     public function __construct()
     {
         $this->createdAt = new DateTimeImmutable();
         $this->modifiedAt = new DateTimeImmutable();
+        $this->relatedMessages = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -123,6 +135,48 @@ class Message
     public function setContent(string $content): static
     {
         $this->content = $content;
+
+        return $this;
+    }
+
+    public function getRepliedMessage(): ?self
+    {
+        return $this->repliedMessage;
+    }
+
+    public function setRepliedMessage(?self $repliedMessage): static
+    {
+        $this->repliedMessage = $repliedMessage;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, self>
+     */
+    public function getRelatedMessages(): Collection
+    {
+        return $this->relatedMessages;
+    }
+
+    public function addRelatedMessage(self $relatedMessage): static
+    {
+        if (!$this->relatedMessages->contains($relatedMessage)) {
+            $this->relatedMessages->add($relatedMessage);
+            $relatedMessage->setRepliedMessage($this);
+        }
+
+        return $this;
+    }
+
+    public function removeRelatedMessage(self $relatedMessage): static
+    {
+        if ($this->relatedMessages->removeElement($relatedMessage)) {
+            // set the owning side to null (unless already changed)
+            if ($relatedMessage->getRepliedMessage() === $this) {
+                $relatedMessage->setRepliedMessage(null);
+            }
+        }
 
         return $this;
     }


### PR DESCRIPTION
This pull request introduces a new "reply to message" feature in the chat application, along with improvements to message handling, such as editing and deleting messages. It includes updates to the frontend, backend, and database schema to support these functionalities.

### New "Reply to Message" Feature:

* **Frontend Integration**:
  - Added `onScrollToMessage` prop to the `MessageComponent` and `MessageList` components to enable scrolling to a specific message when a reply is clicked. (`assets/components/chat/Message.tsx` - [[1]](diffhunk://#diff-9d58c93d9a874c7478e976c1055847de055d58fc18dd67b392992e777a46a0bfR25) [[2]](diffhunk://#diff-9d58c93d9a874c7478e976c1055847de055d58fc18dd67b392992e777a46a0bfR205-R238); `assets/pages/Chat/components/MessageList.tsx` - [[3]](diffhunk://#diff-09a88c58a1881058db4968867c1b9f2e6c12c8ebe3966c4a89ff40735882de1eR15) [[4]](diffhunk://#diff-09a88c58a1881058db4968867c1b9f2e6c12c8ebe3966c4a89ff40735882de1eR54)
  - Implemented a visual reply preview in the `MessageComponent` that shows the replied-to message with a clickable highlight. (`assets/components/chat/Message.tsx` - [assets/components/chat/Message.tsxR205-R238](diffhunk://#diff-9d58c93d9a874c7478e976c1055847de055d58fc18dd67b392992e777a46a0bfR205-R238))
  - Added `handleScrollToMessage` in the `Discussion` component to scroll to and highlight the replied-to message. (`assets/pages/Chat/Discussion.tsx` - [[1]](diffhunk://#diff-b5369dc39f83c377e90af050a267d3d46bee00338530436af0832dc93269fa89R68-L73) [[2]](diffhunk://#diff-b5369dc39f83c377e90af050a267d3d46bee00338530436af0832dc93269fa89R138)

* **Backend Support**:
  - Updated the `MessagesController` to handle replies by linking messages via a new `repliedMessageId` parameter. (`src/Controller/MessagesController.php` - [src/Controller/MessagesController.phpL37-R51](diffhunk://#diff-60496914ecb95091ced476207c15151129335a5e88098f3a1c43e5a6aef5cb23L37-R51))
  - Added a database migration to include a `replied_message_id` column in the `message` table. (`migrations/Version20250726221802.php` - [migrations/Version20250726221802.phpR1-R36](diffhunk://#diff-f8d4bd2acd23d8cb1b44f6190870ca4aa45cbaaa0b80cdf25be4a7e415780f26R1-R36))

### Enhanced Message Handling:

* **Edit and Delete Messages**:
  - Implemented `handleEditMessage` and `handleDeleteMessage` functions in `useChatActions` to allow editing and deleting messages via API calls. (`assets/pages/Chat/hooks/useChatActions.ts` - [assets/pages/Chat/hooks/useChatActions.tsR2-R30](diffhunk://#diff-48bdca2f2f5ad9e3b5020206c7e757a4853f62e0091f9be3bc4f9e26125f8b59R2-R30))
  - Added corresponding backend routes for editing (`PUT`) and deleting (`DELETE`) messages, with event dispatching for updates. (`src/Controller/MessagesController.php` - [src/Controller/MessagesController.phpR115-R131](diffhunk://#diff-60496914ecb95091ced476207c15151129335a5e88098f3a1c43e5a6aef5cb23R115-R131))

* **State Management**:
  - Added `deleteMessage` and `updateMessage` actions to the `useAppStore` state management. These actions update the `conversations` state when a message is deleted or edited. (`assets/lib/store.ts` - [assets/lib/store.tsR88-R107](diffhunk://#diff-454559957efaa2b3cc6fe76dfdfb697ce8359600963d8ce81e3e9725023ff203R88-R107))

### Miscellaneous Updates:

* **API Enhancements**:
  - Updated the `useSendMessage` hook to include `repliedMessage` when sending a new message. (`assets/pages/Chat/hooks/useSendMessage.ts` - [assets/pages/Chat/hooks/useSendMessage.tsL7-R13](diffhunk://#diff-9cf963aca74286c4640e6c209e6ef910863c05bcab2489c92cec696281f1919eL7-R13))

* **Schema and Type Updates**:
  - Updated the `Message` type to include a `repliedMessage` field and refactored the `MessageEvent` type for better structure. (`assets/types.ts` - [assets/types.tsR27-R39](diffhunk://#diff-d2b431cbf39254468ce0a67cd9ebe0252736973105a3ede43219a2a19ab03c96R27-R39))
  - Added `symfony/object-mapper` to dependencies for improved object mapping. (`composer.json` - [composer.jsonR29](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R29))